### PR TITLE
Locating textures in the map without reloading

### DIFF
--- a/BveClassWrappers.cs
+++ b/BveClassWrappers.cs
@@ -15,30 +15,38 @@ namespace Zbx1425.DXDynamicTexture {
 
             class BveModelInfoClassWrapper {
 
+                private static bool haveFieldInfosSet = false;
+
                 public object Src { get; }
 
                 public BveModelInfoClassWrapper(object src) {
                     Src = src;
-                    Type type = src.GetType();
-                    FieldInfo[] fields = type.GetFields(DefaultBindingFlags);
-                    MeshField = fields.First(f => f.FieldType == typeof(Mesh));
-                    MaterialInfosField = fields.First(f => {
-                        if (!f.FieldType.IsArray) return false;
 
-                        var materialInfoTypeFields = f.FieldType.GetElementType().GetFields(DefaultBindingFlags);
-                        bool hasMaterialTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Material));
-                        bool hasTextureTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Texture));
+                    if (!haveFieldInfosSet) {
+                        Type type = src.GetType();
+                        FieldInfo[] fields = type.GetFields(DefaultBindingFlags);
 
-                        return hasMaterialTypeField && hasTextureTypeField;
-                    });
+                        MeshField = MeshField ?? fields.First(f => f.FieldType == typeof(Mesh));
+                        MaterialInfosField = MaterialInfosField ?? fields.First(f => {
+                            if (!f.FieldType.IsArray) return false;
+
+                            var materialInfoTypeFields = f.FieldType.GetElementType().GetFields(DefaultBindingFlags);
+                            bool hasMaterialTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Material));
+                            bool hasTextureTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Texture));
+
+                            return hasMaterialTypeField && hasTextureTypeField;
+                        });
+
+                        haveFieldInfosSet = true;
+                    }
                 }
 
-                private FieldInfo MeshField;
+                private static FieldInfo MeshField;
                 public Mesh Mesh {
                     get => MeshField.GetValue(Src) as Mesh;
                 }
 
-                private FieldInfo MaterialInfosField;
+                private static FieldInfo MaterialInfosField;
                 public BveMaterialInfoClassWrapper[] MaterialInfos {
                     get {
                         object[] objs = MaterialInfosField.GetValue(Src) as object[];
@@ -53,23 +61,30 @@ namespace Zbx1425.DXDynamicTexture {
 
             class BveMaterialInfoClassWrapper {
 
+                private static bool haveFieldInfosSet = false;
+
                 public object Src { get; }
 
                 public BveMaterialInfoClassWrapper(object src) {
                     Src = src;
-                    Type type = src.GetType();
-                    FieldInfo[] fields = type.GetFields(DefaultBindingFlags);
-                    MaterialField = fields.FirstOrDefault(f => f.FieldType == typeof(Material));
-                    TextureField = fields.FirstOrDefault(f => f.FieldType == typeof(Texture));
+
+                    if (!haveFieldInfosSet) {
+                        Type type = src.GetType();
+                        FieldInfo[] fields = type.GetFields(DefaultBindingFlags);
+                        MaterialField = fields.FirstOrDefault(f => f.FieldType == typeof(Material));
+                        TextureField = fields.FirstOrDefault(f => f.FieldType == typeof(Texture));
+
+                        haveFieldInfosSet = true;
+                    }
                 }
 
-                private FieldInfo MaterialField;
+                private static FieldInfo MaterialField;
                 public Material Material {
                     get => (Material)MaterialField.GetValue(Src);
                     set => MaterialField.SetValue(Src, value);
                 }
 
-                private FieldInfo TextureField;
+                private static FieldInfo TextureField;
                 public Texture Texture {
                     get => TextureField.GetValue(Src) as Texture;
                     set => TextureField.SetValue(Src, value);

--- a/BveClassWrappers.cs
+++ b/BveClassWrappers.cs
@@ -35,14 +35,19 @@ namespace Zbx1425.DXDynamicTexture {
 
                 private FieldInfo MeshField;
                 public Mesh Mesh {
-                    get => (Mesh)MeshField.GetValue(Src);
+                    get => MeshField.GetValue(Src) as Mesh;
                 }
 
                 private FieldInfo MaterialInfosField;
                 public BveMaterialInfoClassWrapper[] MaterialInfos {
-                    get => ((object[])MaterialInfosField.GetValue(Src))
-                        .Select(material => new BveMaterialInfoClassWrapper(material))
-                        .ToArray();
+                    get {
+                        object[] objs = MaterialInfosField.GetValue(Src) as object[];
+                        BveMaterialInfoClassWrapper[] result = new BveMaterialInfoClassWrapper[objs.Length];
+                        for (int i = 0; i < objs.Length; i++) {
+                            result[i] = new BveMaterialInfoClassWrapper(objs[i]);
+                        }
+                        return result;
+                    }
                 }
             }
 
@@ -66,7 +71,7 @@ namespace Zbx1425.DXDynamicTexture {
 
                 private FieldInfo TextureField;
                 public Texture Texture {
-                    get => (Texture)TextureField.GetValue(Src);
+                    get => TextureField.GetValue(Src) as Texture;
                     set => TextureField.SetValue(Src, value);
                 }
             }

--- a/BveClassWrappers.cs
+++ b/BveClassWrappers.cs
@@ -1,0 +1,75 @@
+using SlimDX.Direct3D9;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Windows.Forms;
+
+namespace Zbx1425.DXDynamicTexture {
+
+    public static partial class TextureManager {
+
+        internal static partial class PostInstantiateTexturePatcher {
+
+            class BveModelInfoClassWrapper {
+
+                public object Src { get; }
+
+                public BveModelInfoClassWrapper(object src) {
+                    Src = src;
+                    Type type = src.GetType();
+                    FieldInfo[] fields = type.GetFields(DefaultBindingFlags);
+                    MeshField = fields.First(f => f.FieldType == typeof(Mesh));
+                    MaterialInfosField = fields.First(f => {
+                        if (!f.FieldType.IsArray) return false;
+
+                        var materialInfoTypeFields = f.FieldType.GetElementType().GetFields(DefaultBindingFlags);
+                        bool hasMaterialTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Material));
+                        bool hasTextureTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Texture));
+
+                        return hasMaterialTypeField && hasTextureTypeField;
+                    });
+                }
+
+                private FieldInfo MeshField;
+                public Mesh Mesh {
+                    get => (Mesh)MeshField.GetValue(Src);
+                }
+
+                private FieldInfo MaterialInfosField;
+                public BveMaterialInfoClassWrapper[] MaterialInfos {
+                    get => ((object[])MaterialInfosField.GetValue(Src))
+                        .Select(material => new BveMaterialInfoClassWrapper(material))
+                        .ToArray();
+                }
+            }
+
+            class BveMaterialInfoClassWrapper {
+
+                public object Src { get; }
+
+                public BveMaterialInfoClassWrapper(object src) {
+                    Src = src;
+                    Type type = src.GetType();
+                    FieldInfo[] fields = type.GetFields(DefaultBindingFlags);
+                    MaterialField = fields.FirstOrDefault(f => f.FieldType == typeof(Material));
+                    TextureField = fields.FirstOrDefault(f => f.FieldType == typeof(Texture));
+                }
+
+                private FieldInfo MaterialField;
+                public Material Material {
+                    get => (Material)MaterialField.GetValue(Src);
+                    set => MaterialField.SetValue(Src, value);
+                }
+
+                private FieldInfo TextureField;
+                public Texture Texture {
+                    get => (Texture)TextureField.GetValue(Src);
+                    set => TextureField.SetValue(Src, value);
+                }
+            }
+        }
+    }
+}

--- a/DXDynamicTexture.csproj
+++ b/DXDynamicTexture.csproj
@@ -81,15 +81,30 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GDIHelper.cs" />
+    <Compile Include="ProgressForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ProgressForm.Designer.cs">
+      <DependentUpon>ProgressForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="TextureHandle.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="BveClassWrappers.cs" />
+    <Compile Include="TextureManager.PostInstantiateTexturePatcher.cs" />
+    <Compile Include="TextureManager.PreInstantiateTexturePatcher.cs" />
     <Compile Include="TextureManager.cs" />
     <Compile Include="TouchEventArgs.cs" />
     <Compile Include="TouchManager.cs" />
+    <Compile Include="EnumerableExtensions.cs" />
     <Compile Include="TouchTextureHandle.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ProgressForm.resx">
+      <DependentUpon>ProgressForm.cs</DependentUpon>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/EnumerableExtensions.cs
+++ b/EnumerableExtensions.cs
@@ -1,0 +1,31 @@
+using SlimDX.Direct3D9;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Windows.Forms;
+
+namespace Zbx1425.DXDynamicTexture {
+
+    public static class EnumerableExtensions {
+
+        public static IEnumerable<T> ToEnumerable<T>(this T obj) {
+            yield return obj;
+        }
+
+        public static IEnumerable<T> Flatten<T>(this IEnumerable<T> src) {
+            return src
+                .Select(obj => {
+                    if (obj is IEnumerable<T> arrayObj) {
+                        return arrayObj.Flatten();
+                    } else {
+                        return obj.ToEnumerable();
+                    }
+                })
+                .SelectMany(x => x);
+        }
+    }
+}

--- a/EnumerableExtensions.cs
+++ b/EnumerableExtensions.cs
@@ -12,17 +12,13 @@ namespace Zbx1425.DXDynamicTexture {
 
     public static class EnumerableExtensions {
 
-        public static IEnumerable<T> ToEnumerable<T>(this T obj) {
-            yield return obj;
-        }
-
         public static IEnumerable<T> Flatten<T>(this IEnumerable<T> src) {
             return src
                 .Select(obj => {
                     if (obj is IEnumerable<T> arrayObj) {
                         return arrayObj.Flatten();
                     } else {
-                        return obj.ToEnumerable();
+                        return new T[1] { obj };
                     }
                 })
                 .SelectMany(x => x);

--- a/ProgressForm.Designer.cs
+++ b/ProgressForm.Designer.cs
@@ -1,0 +1,110 @@
+﻿namespace Zbx1425.DXDynamicTexture {
+
+    partial class ProgressForm {
+
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing) {
+            if (disposing && (components != null)) {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent() {
+            this.captionLabel_JP = new System.Windows.Forms.Label();
+            this.progressBar = new System.Windows.Forms.ProgressBar();
+            this.detailLabel = new System.Windows.Forms.Label();
+            this.captionLabel_EN = new System.Windows.Forms.Label();
+            this.backgroundWorker = new System.ComponentModel.BackgroundWorker();
+            this.SuspendLayout();
+            // 
+            // captionLabel_JP
+            // 
+            this.captionLabel_JP.AutoSize = true;
+            this.captionLabel_JP.Font = new System.Drawing.Font("MS UI Gothic", 9F);
+            this.captionLabel_JP.Location = new System.Drawing.Point(16, 20);
+            this.captionLabel_JP.Name = "captionLabel_JP";
+            this.captionLabel_JP.Size = new System.Drawing.Size(143, 12);
+            this.captionLabel_JP.TabIndex = 0;
+            this.captionLabel_JP.Text = "テクスチャを置き換えています...";
+            // 
+            // progressBar
+            // 
+            this.progressBar.Location = new System.Drawing.Point(16, 60);
+            this.progressBar.Name = "progressBar";
+            this.progressBar.Size = new System.Drawing.Size(288, 24);
+            this.progressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
+            this.progressBar.TabIndex = 1;
+            // 
+            // detailLabel
+            // 
+            this.detailLabel.AutoSize = true;
+            this.detailLabel.Font = new System.Drawing.Font("MS UI Gothic", 9F);
+            this.detailLabel.Location = new System.Drawing.Point(16, 92);
+            this.detailLabel.Name = "detailLabel";
+            this.detailLabel.Size = new System.Drawing.Size(56, 12);
+            this.detailLabel.TabIndex = 2;
+            this.detailLabel.Text = "Initializing";
+            // 
+            // captionLabel_EN
+            // 
+            this.captionLabel_EN.AutoSize = true;
+            this.captionLabel_EN.Font = new System.Drawing.Font("MS UI Gothic", 9F);
+            this.captionLabel_EN.Location = new System.Drawing.Point(16, 36);
+            this.captionLabel_EN.Name = "captionLabel_EN";
+            this.captionLabel_EN.Size = new System.Drawing.Size(101, 12);
+            this.captionLabel_EN.TabIndex = 3;
+            this.captionLabel_EN.Text = "Patching textures...";
+            // 
+            // backgroundWorker
+            // 
+            this.backgroundWorker.WorkerReportsProgress = true;
+            this.backgroundWorker.DoWork += new System.ComponentModel.DoWorkEventHandler(this.backgroundWorker_DoWork);
+            this.backgroundWorker.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.backgroundWorker_ProgressChanged);
+            this.backgroundWorker.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.backgroundWorker_RunWorkerCompleted);
+            // 
+            // ProgressForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(320, 120);
+            this.ControlBox = false;
+            this.Controls.Add(this.captionLabel_EN);
+            this.Controls.Add(this.detailLabel);
+            this.Controls.Add(this.progressBar);
+            this.Controls.Add(this.captionLabel_JP);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "ProgressForm";
+            this.Text = "DXDynamicTexture";
+            this.TopMost = true;
+            this.Shown += new System.EventHandler(this.ProgressForm_Shown);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label captionLabel_JP;
+        private System.Windows.Forms.ProgressBar progressBar;
+        private System.Windows.Forms.Label detailLabel;
+        private System.Windows.Forms.Label captionLabel_EN;
+        private System.ComponentModel.BackgroundWorker backgroundWorker;
+    }
+}

--- a/ProgressForm.cs
+++ b/ProgressForm.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Windows.Forms;
+
+namespace Zbx1425.DXDynamicTexture {
+    public partial class ProgressForm : Form {
+
+        private Action Work;
+
+        private int InspectedObjCount = 0;
+        private int PatchedTextureCount = 0;
+
+        public ProgressForm() {
+            InitializeComponent();
+        }
+
+        public void SetWork(Action work) => Work = work;
+
+        private void ProgressForm_Shown(object sender, EventArgs e) {
+            backgroundWorker.RunWorkerAsync();
+        }
+
+        private void backgroundWorker_DoWork(object sender, DoWorkEventArgs e) {
+            Work();
+        }
+
+        public void ReportProgress(int? progressPercentage, string status) {
+            backgroundWorker.ReportProgress(progressPercentage ?? progressBar.Value, status);
+        }
+        public void ReportProgress(int? progressPercentage, int? inspectedObjCount, int? patchedTextureCount) {
+            InspectedObjCount = inspectedObjCount ?? InspectedObjCount;
+            PatchedTextureCount = patchedTextureCount ?? PatchedTextureCount;
+
+            ReportProgress(progressPercentage, $"{InspectedObjCount} object(s) inspected, {PatchedTextureCount} texture(s) patched");
+        }
+
+        private void backgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e) {
+            progressBar.Value = e.ProgressPercentage;
+            detailLabel.Text = (string)e.UserState;
+            Update();
+        }
+
+        private void backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e) {
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/ProgressForm.resx
+++ b/ProgressForm.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="backgroundWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/README.md
+++ b/README.md
@@ -114,9 +114,12 @@ Next, in your Load() function,initialize the TextureManager (you need to `using 
 ```csharp
 [DllExport(CallingConvention.StdCall)]
 public static void Load() {
-    TextureManager.Initialize();
+    TextureManager.Initialize(true);
 }
 ```
+
+The TextureManager.Initialize method parameter specifies whether to replace textures that are "registered" at the time this method is executed, such as textures in the map.  
+The parameter can also be omitted, in which case it is assumed to be true.
 
 Now compile the plugin and start the game, to see if there are any errors.
 
@@ -134,7 +137,7 @@ private static string dllParentPath = Path.GetDirectoryName(System.Reflection.As
 
 [DllExport(CallingConvention.StdCall)]
 public static void Load() {
-    TextureManager.Initialize();
+    TextureManager.Initialize(true);
     hTex = TextureManager.Register("clock_back_tex.png", 128, 128);
     gClock = new GDIHelper(128, 128);
     imgClock = new Bitmap(Path.Combine(dllParentPath, "clock_back.png"));
@@ -181,8 +184,9 @@ Now we'll explain how it works.
   You should call `Register` in the Load event, then check `IsCreated` in the Tick event.
   It locates and replaces a texture file (discarding its content) with a new blank texture.
 
-  Due to limitations, textures on the train panel can be located directly, but textures outside in the scenario map requires the player close and reopen the scenario to be located. So you should check if your texture has `IsCreated` in `Tick`, and if not, show a tip message on the panel to remind the player to close and reopen the scenario.
-
+  Due to limitations, textures on the train panel can be located directly, but textures in the map requires another way to be located; set the TextureManager.Initialize method parameter to true or omit it. This will enable the option to allow textures that are "registered" at the time TextureManager.Initialize is executed (e.g., textures in the map) to be replaced.  
+  If TextureManager fails locating the texture, the IsCreated property will be false. You should check if your texture has `IsCreated` in `Tick`, and if not, show a tip message on the panel to remind the player to close and reopen the scenario.
+  
   - texturePathSuffix: A part of the path of the texture in scenraio you want to replace. For example, for `....../Scenario/shuttle/hrd/structures/back_a.png` you should use `shuttle/hrd/structures/back_a.png`.
   - width, height: The size of the new texture. Width and Height needs to be a power of 2. Don't need to be the same as the original texture.
   
@@ -230,7 +234,7 @@ private static TouchTextureHandle hTIMSTex;
 
 [DllExport(CallingConvention.StdCall)]
 public static void Load(){
-    TextureManager.Initialize();
+    TextureManager.Initialize(true);
     hTIMSTex = TouchManager.Register("foo/bar/tims_placeholder.png", 512, 512);
     hTIMSTex.SetClickableArea(0, 0, 400, 300);
     TouchManager.EnableEvent(MouseButtons.Left, TouchManager.EventType.Down);

--- a/README_JP.md
+++ b/README_JP.md
@@ -117,9 +117,11 @@ public static class AtsMain {
 
 [DllExport(CallingConvention.StdCall)]
 public static void Load() {
-    TextureManager.Initialize();
+    TextureManager.Initialize(true);
 }
 ```
+
+TextureManager.Initialize メソッドのパラメータに true が指定されていますが、これはマップ内のテクスチャなど、このメソッドを実行する時点で既に読み込まれたテクスチャを後から置き換えるかどうかを指定するものです。省略した場合は true として処理されます。
 
 ここまで完了したら、ATS プラグインをコンパイルして BVE から読み込み、エラーが発生しないことを確認してください。
 
@@ -143,7 +145,7 @@ private static string dllParentPath = Path.GetDirectoryName(System.Reflection.As
 
 [DllExport(CallingConvention.StdCall)]
 public static void Load() {
-    TextureManager.Initialize();
+    TextureManager.Initialize(true);
     hTex = TextureManager.Register("clock_back_tex.png", 128, 128);
     gClock = new GDIHelper(128, 128);
     imgClock = new Bitmap(Path.Combine(dllParentPath, "clock_back.png"));
@@ -184,7 +186,7 @@ public static AtsHandles Elapse(AtsVehicleState state, IntPtr hPanel, IntPtr hSo
 
 ここからこのコードの解説をしていきます。
 
-- TextureManager.Register(texturePathSuffix*, width*, *height*);
+- TextureManager.Register(*texturePathSuffix*, *width*, *height*);
 
   シナリオの読込中、`texturePathSuffix` で指定したファイル名の画像からテクスチャが生成されるかどうか監視します。
   戻り値は TextureHandle 型で、テクスチャが生成された場合は TextureHandle.IsCreated プロパティ (コード例の場合は `hTex.IsCreated`) が true になります。 
@@ -193,8 +195,8 @@ public static AtsHandles Elapse(AtsVehicleState state, IntPtr hPanel, IntPtr hSo
   
   また、このメソッドは空白のテクスチャで元のテクスチャを置き換えるため注意してください。
   
-  BVE のマップを車両より先に読み込む仕様の関係で、運転台パネル内のテクスチャは直接置き換えられる一方、マップ内のテクスチャを置き換えるには一度マップを読み込んだ後再度読み込み直す必要があります。
-  そのため、マップ内のテクスチャを置き換えている場合は、ゲーム開始時に IsCreated が true になっているか確認し、false であれば、コード例のように利用者に対しシナリオを読み込み直す必要がある旨を表示することを推奨します。
+  BVE のマップを車両より先に読み込む仕様の関係で、運転台パネル内のテクスチャは直接置き換えられる一方、マップ内のテクスチャは既に読込済のため直接置き換えることができません。TextureManager.Initialize メソッドのパラメータに true を指定するか省略すると、既に読み込まれたテクスチャも後から置き換えることができます。  
+  TextureManager.Initialize メソッドのパラメータに false を指定した、BVE の内部実装が大幅に変更され置換処理が正常に実行できなかったなどの理由でテクスチャが置き換えられなかった場合は、IsCreated プロパティが false になります。ゲーム開始時に IsCreated が true になっているか確認し、false であれば、コード例のように利用者に対しシナリオを読み込み直す必要がある旨を表示することを推奨します。
   
   - texturePathSuffix: 置き換えたいテクスチャのパスの一部。例えば `～～～/Scenarios/shuttle/hrd/structures/back_a.png` を置き換えたい場合は `shuttle/hrd/structures/back_a.png` を指定すると良いでしょう。
   - width, height: 置換後のテクスチャのサイズ。いずれも 2 のべき乗である必要があります。置換元のテクスチャのサイズと合わせる必要はありません。
@@ -253,7 +255,7 @@ private static TouchTextureHandle hTIMSTex;
 
 [DllExport(CallingConvention.StdCall)]
 public static void Load(){
-    TextureManager.Initialize();
+    TextureManager.Initialize(true);
     hTIMSTex = TouchManager.Register("foo/bar/tims_placeholder.png", 512, 512);
     hTIMSTex.SetClickableArea(0, 0, 400, 300);
     TouchManager.EnableEvent(MouseButtons.Left, TouchManager.EventType.Down);

--- a/TextureManager.PostInstantiateTexturePatcher.cs
+++ b/TextureManager.PostInstantiateTexturePatcher.cs
@@ -1,0 +1,133 @@
+using SlimDX.Direct3D9;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace Zbx1425.DXDynamicTexture {
+
+    public static partial class TextureManager {
+
+        internal static partial class PostInstantiateTexturePatcher {
+
+            private const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.InvokeMethod;
+
+            public static void Initialize() {
+                Application.OpenForms[0].Invalidated += OnGameBegun;
+            }
+
+            private static void OnGameBegun(object sender, EventArgs e) {
+                Form mainForm = Application.OpenForms[0];
+                mainForm.Invalidated -= OnGameBegun;
+
+                if (Handles.Values.All(h => h.IsCreated)) return;
+
+                var bveAssembly = Assembly.GetEntryAssembly();
+                if (bveAssembly is null) throw new NotSupportedException("Cannot find the BVE Trainsim assembly.");
+
+                ProgressForm progressForm = new ProgressForm();
+                progressForm.SetWork(() => {
+                    var allChildForms = ForEachMembers(mainForm, new List<object>(0), 0)
+                        .FindAll(obj => obj is Form)
+                        .ConvertAll(obj => (Form)obj);
+
+                    int patchedTextureCount = 0;
+                    ForEachMembers(allChildForms.Find(f => f.Name == "SimOperationForm"), new List<object>(0), 4,
+                        obj => {
+                            var modelTypeFields = obj.GetType().GetFields(DefaultBindingFlags);
+                            bool hasMeshTypeField = modelTypeFields.Any(f => f.FieldType == typeof(Mesh));
+                            bool hasMaterialInfoTypeField = modelTypeFields.Any(f => {
+                                if (!f.FieldType.IsArray) return false;
+
+                                var materialInfoTypeFields = f.FieldType.GetElementType().GetFields(DefaultBindingFlags);
+                                bool hasMaterialTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Material));
+                                bool hasTextureTypeField = materialInfoTypeFields.Any(f2 => f2.FieldType == typeof(Texture));
+
+                                return hasMaterialTypeField && hasTextureTypeField;
+                            });
+
+                            return hasMeshTypeField && hasMaterialInfoTypeField;
+                        }, obj => {
+                            var model = new BveModelInfoClassWrapper(obj);
+
+                            var texturePaths = model.Mesh.GetMaterials()
+                                .Select(m => m.TextureFileName)
+                                .ToArray();
+
+                            for (int i = 0; i < model.MaterialInfos.Length; i++) {
+                                Texture texture = TryPatch(texturePaths[i]);
+                                if (texture != null) {
+                                    var materialInfo = model.MaterialInfos[i];
+                                    materialInfo.Texture = texture;
+                                    DXDevice.Material = materialInfo.Material;
+                                    DXDevice.SetTexture(0, texture);
+                                    model.Mesh.DrawSubset(i);
+
+                                    patchedTextureCount++;
+                                    progressForm.ReportProgress(null, null, patchedTextureCount);
+                                }
+                            }
+                        });
+
+                    progressForm.ReportProgress(100, "Completed.");
+                });
+                progressForm.Show(mainForm);
+
+                
+                List<object> ForEachMembers(
+                    object parent, List<object> recognizedObjs, int maxNestCount,
+                    Func<object, bool> targetObjSelector = null, Action<object> action = null, int defaultCapacity = 0) {
+
+                    if (maxNestCount < 0) return new List<object>(0);
+
+                    if (targetObjSelector == null) targetObjSelector = _ => false;
+                    if (action == null) action = _ => { };
+
+                    var parentType = parent.GetType();
+                    var fields = parentType.GetFields(DefaultBindingFlags);
+
+                    var unrecognizedObjs = fields
+                        .Where(f => IsUniqueType(f.FieldType)) // Search only for fields of BVE's unique types; target textures are only instantiated with those fields
+                        .Select(f => f.GetValue(parent))
+                        .Flatten()
+                        .Except(recognizedObjs) // Exclude objects already recognized
+                        .Where(obj => obj != null && obj != parent);
+
+                    var targetObjs = unrecognizedObjs.Where(targetObjSelector);
+                    if (targetObjs.Any()) {
+                        foreach (var obj in targetObjs) action(obj);
+                    }
+
+                    var objs = new List<object>(defaultCapacity <= 0 ? recognizedObjs.Count + unrecognizedObjs.Count() : defaultCapacity);
+                    objs.AddRange(recognizedObjs);
+                    objs.AddRange(unrecognizedObjs);
+
+                    foreach (var obj in unrecognizedObjs) {
+                        var childObjs = ForEachMembers(obj, objs, maxNestCount - 1, targetObjSelector, action, defaultCapacity + objs.Count);
+                        objs.AddRange(childObjs.Except(objs));
+
+                        if (childObjs.Any()) {
+                            int progress = objs.Count / 200;
+                            if (progress > 99) progress = 99;
+                            progressForm.ReportProgress(progress, objs.Count, null);
+                        }
+                    }
+
+                    return objs;
+
+
+                    bool IsUniqueType(Type type) {
+                        if (type.IsEnum) return false;
+
+                        return type.Assembly == bveAssembly
+                            || (type.IsGenericType && type.GetGenericArguments().Any(IsUniqueType));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TextureManager.PreInstantiateTexturePatcher.cs
+++ b/TextureManager.PreInstantiateTexturePatcher.cs
@@ -1,0 +1,51 @@
+using HarmonyLib;
+using SlimDX.Direct3D9;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace Zbx1425.DXDynamicTexture {
+
+    public static partial class TextureManager {
+
+        internal static class PreInstantiateTexturePatcher {
+
+            public static Harmony Harmony;
+
+            static PreInstantiateTexturePatcher() {
+                AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
+            }
+
+            private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args) {
+                if (args.Name.Contains("Harmony")) {
+                    if (DllDir == null) DllDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                    if (Environment.Version.Major >= 4) {
+                        return Assembly.LoadFile(Path.Combine(DllDir, "Harmony-net48.dll"));
+                    } else {
+                        return Assembly.LoadFile(Path.Combine(DllDir, "Harmony-net35.dll"));
+                    }
+                }
+                return null;
+            }
+
+            public static void Initialize() {
+                Harmony = new Harmony("cn.zbx1425.dxdynamictexture");
+                Harmony.Patch(typeof(Texture).GetMethods()
+                    .Where(m => m.Name == nameof(Texture.FromFile) && m.GetParameters().Length == 11)
+                    .FirstOrDefault(),
+                    null, new HarmonyMethod(typeof(PreInstantiateTexturePatcher), nameof(FromFilePostfix))
+                );
+            }
+
+            private static void FromFilePostfix(ref Texture __result, Device device, string fileName) {
+                if (DXDevice == null) DXDevice = device;
+
+                var texture = TryPatch(fileName);
+                if (texture != null) __result = texture;
+            }
+        }
+    }
+}

--- a/TextureManager.cs
+++ b/TextureManager.cs
@@ -1,4 +1,3 @@
-using HarmonyLib;
 using SlimDX.Direct3D9;
 using System;
 using System.Collections.Generic;
@@ -9,50 +8,19 @@ using System.Text;
 
 namespace Zbx1425.DXDynamicTexture {
 
-    public static class TextureManager {
+    public static partial class TextureManager {
 
-        internal static Harmony Harmony;
         internal static Dictionary<string, TextureHandle> Handles = new Dictionary<string, TextureHandle>();
 
         internal static string DllDir;
 
         internal static Device DXDevice;
 
-        static TextureManager() {
-            AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
-        }
-
-        public static void Initialize() {
-            Harmony = new Harmony("cn.zbx1425.dxdynamictexture");
-            Harmony.Patch(typeof(Texture).GetMethods()
-                .Where(m => m.Name == "FromFile" && m.GetParameters().Length == 11)
-                .FirstOrDefault(),
-                null, new HarmonyMethod(typeof(TextureManager), "FromFilePostfix")
-            );
+        public static void Initialize(bool modifyInstancedTextures = true) {
+            PreInstantiateTexturePatcher.Initialize();
+            if (modifyInstancedTextures) PostInstantiateTexturePatcher.Initialize();
 
             TouchManager.Initialize();
-        }
-        
-        private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args) {
-            if (args.Name.Contains("Harmony")) {
-                if (DllDir == null) DllDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-                if (Environment.Version.Major >= 4) {
-                    return Assembly.LoadFile(Path.Combine(DllDir, "Harmony-net48.dll"));
-                } else {
-                    return Assembly.LoadFile(Path.Combine(DllDir, "Harmony-net35.dll"));
-                }
-            }
-            return null;
-        }
-
-        private static void FromFilePostfix(ref Texture __result, Device device, string fileName) {
-            var normalizedName = fileName.Replace('\\', '/').ToLowerInvariant();
-            foreach (var item in Handles) {
-                if (normalizedName.EndsWith(item.Key)) {
-                    __result = Handles[item.Key].GetOrCreate(device);
-                }
-            }
-            DXDevice = device;
         }
 
         public static TextureHandle Register(string fileNameEnding, int width, int height) {
@@ -69,6 +37,21 @@ namespace Zbx1425.DXDynamicTexture {
 
         internal static bool IsPowerOfTwo(int x) {
             return (x & (x - 1)) == 0;
+        }
+
+        private static Texture TryPatch(string fileName) {
+            var normalizedName = fileName.Replace('\\', '/').ToLowerInvariant();
+            foreach (var item in Handles) {
+                if (normalizedName.EndsWith(item.Key)) {
+                    if (Handles[item.Key].IsCreated) {
+                        return null;
+                    } else {
+                        return Handles[item.Key].GetOrCreate(DXDevice);
+                    }
+                }
+            }
+
+            return null;
         }
 
         public static void Dispose() {

--- a/TouchManager.cs
+++ b/TouchManager.cs
@@ -36,7 +36,7 @@ namespace Zbx1425.DXDynamicTexture {
         internal static void Initialize() {
             try {
                 Form mainForm = Application.OpenForms[0];
-                TextureManager.Harmony.Patch(
+                TextureManager.PreInstantiateTexturePatcher.Harmony.Patch(
                     mainForm.GetType().GetMethod("OnPaint", BindingFlags.NonPublic | BindingFlags.Instance),
                     new HarmonyMethod(typeof(TouchManager), "OnPaintPrefix"),
                     new HarmonyMethod(typeof(TouchManager), "OnPaintPostfix")


### PR DESCRIPTION
This PR allows to locate textures in the map without reloading the scenario.

## Changes
- Add a `TextureManager.PostInstantiateTexturePatcher` class
  - This class allows replacing textures that are already registered.
  - After the scenario is loaded, this class will search for instances that define `Texture` of `Material`, and replace the target textures.
  - Searching instances takes some time (especially in large scenarios), so I also created a `ProgressForm` class, which displays the current progress of searching and replacing (see "UI Sample" for more details)
- Move the existing feature to a `TextureManager.PreInstantiateTexturePatcher` class
- Add a `bool` parameter to `TextureManager.Initialize` method
  - true or omitted -> search and replace textures that are already registered
  - false -> do not replace (same as the current version of DXDynamicTexture)
```C#
[DllExport(CallingConvention.StdCall)]
public static void Load() {
    TextureManager.Initialize(true);
    Texture = DynamicTexture.Create(@"clock_back_tex.png", 128, 128);
}
```
- Update README according to the changes
- And few changes

## UI Sample
https://user-images.githubusercontent.com/67314487/157707549-346ba39a-532c-4c2e-9b67-59fd7e9c69a2.mp4

NOTE: If all of `TextureManager.Handles` have been created (=`TextureManager.Handles.All(h => h.IsCreated)`), the search and replace process is skipped even if the `TextureManager.Initialize` method parameter is `true`.