### PR TITLE
Allow user logic for locating textures

### DIFF
--- a/TextureHandle.cs
+++ b/TextureHandle.cs
@@ -27,6 +27,14 @@ namespace Zbx1425.DXDynamicTexture {
             this.Width = width; this.Height = height;
         }
 
+        internal TextureHandle(Texture texture) {
+            DXTexture = texture;
+            Description = texture.GetLevelDescription(0);
+            if (Description.Format != Format.A8R8G8B8) throw new NotSupportedException("The format of the texture must be Format.A8R8G8B8.");
+            Width = Description.Width;
+            Height = Description.Height;
+        }
+
         private Texture _DXTexture;
         public Texture DXTexture {
             get {

--- a/TextureManager.cs
+++ b/TextureManager.cs
@@ -67,6 +67,20 @@ namespace Zbx1425.DXDynamicTexture {
             return result;
         }
 
+        public static TextureHandle Register(Texture texture) {
+            foreach (var item in Handles) {
+                if (item.Value?.DXTexture == texture) return item.Value;
+            }
+
+            var result = new TextureHandle(texture);
+            string guidString;
+            do {
+                guidString = Guid.NewGuid().ToString();
+            } while (Handles.ContainsKey(guidString));
+            Handles.Add(guidString, result);
+            return result;
+        }
+
         internal static bool IsPowerOfTwo(int x) {
             return (x & (x - 1)) == 0;
         }

--- a/TouchManager.cs
+++ b/TouchManager.cs
@@ -149,6 +149,21 @@ namespace Zbx1425.DXDynamicTexture {
             return result;
         }
 
+        public static TouchTextureHandle Register(Texture texture) {
+            foreach (var item in TextureManager.Handles) {
+                if (item.Value?.DXTexture == texture) return (TouchTextureHandle)item.Value;
+            }
+
+            var result = new TouchTextureHandle(texture);
+            Handles.Add(result);
+            string guidString;
+            do {
+                guidString = Guid.NewGuid().ToString();
+            } while (TextureManager.Handles.ContainsKey(guidString));
+            TextureManager.Handles.Add(guidString, result);
+            return result;
+        }
+
         private static Bitmap screenPixel = new Bitmap(1, 1, PixelFormat.Format32bppArgb);
 
         private static Color GetColorAt(Point location) {

--- a/TouchTextureHandle.cs
+++ b/TouchTextureHandle.cs
@@ -26,6 +26,12 @@ namespace Zbx1425.DXDynamicTexture {
             clickableArea = new Rectangle(0, 0, width, height);
         }
 
+        internal TouchTextureHandle(Texture texture) : base(texture) {
+            tempBufferA = new byte[Width * Height * PIXEL_LEN];
+            tempBufferB = new byte[Width * Height * PIXEL_LEN];
+            clickableArea = new Rectangle(0, 0, Width, Height);
+        }
+
         public void SetClickableArea(int x0, int y0, int width, int height) {
             clickableArea = new Rectangle(x0, y0, width, height);
             Array.Clear(tempBufferB, 0, tempBufferB.Length);


### PR DESCRIPTION
Sorry to take the liberty, but I'd like to be able to replace textures with user logic in DXDynamicTexture - I'd like to reference DXDynamicTexture from a library I'm now developing, which already has the ability to directly get Texture instances of structures (please see https://github.com/automatic9045/AtsEX for details).

## Changes
### `TextureManager` / `TouchManager`: Add types of `Register` methods with a parameter of type `Texture`
Since the file name of the texture cannot be specified, a unique GUID string is used as the key for`Handles` instead.
https://github.com/zbx1425/DXDynamicTexture/blob/e49dad67ee0d757e23bc2d877d124f51fcb55b61/TextureManager.cs#L70-L82
https://github.com/zbx1425/DXDynamicTexture/blob/e49dad67ee0d757e23bc2d877d124f51fcb55b61/TouchManager.cs#L152-L165

### `TextureHandle` / `TouchTextureHandle`: Add types of constructors with a parameter of type `Texture`
https://github.com/zbx1425/DXDynamicTexture/blob/e49dad67ee0d757e23bc2d877d124f51fcb55b61/TextureHandle.cs#L30-L36
https://github.com/zbx1425/DXDynamicTexture/blob/e49dad67ee0d757e23bc2d877d124f51fcb55b61/TouchTextureHandle.cs#L29-L33